### PR TITLE
fix: remove erroneous assignment of remove_edges_from nx_graph

### DIFF
--- a/ml4co_kit/solver/mis/base.py
+++ b/ml4co_kit/solver/mis/base.py
@@ -426,7 +426,7 @@ class MISSolver(SolverBase):
                     self_loop = self_loop.reshape(-1, 1).repeat(2, axis=1)
                     edge_index = np.concatenate([self_loop, edge_index.T], axis=0)
                     nx_graph: nx.Graph = nx.from_edgelist(edge_index)
-                    nx_graph = nx_graph.remove_edges_from(nx.selfloop_edges(nx_graph))
+                    nx_graph.remove_edges_from(nx.selfloop_edges(nx_graph))
                 else:
                     nx_graph = nx.from_edgelist(edge_index.T)
 


### PR DESCRIPTION
NetworkX's remove_edges_from() is an in-place operation that returns None. Previously assigning the return value to nx_graph caused unintended None assignment. Removing the assignment preserves the graph object while correctly removing self-loop edges.