### PR TITLE
Fix: Correct indentation in _generate_cluster method

### DIFF
--- a/ml4co_kit/generator/tsp_data.py
+++ b/ml4co_kit/generator/tsp_data.py
@@ -125,14 +125,14 @@ class TSPDataGenerator(EdgeGeneratorBase):
         for i in range(self.num_threads):
             cluster_centers = np.random.random([self.cluster_nums, 2])
             cluster_points = []
-        for center in cluster_centers:
-            points = np.random.normal(
-                loc=center,
-                scale=self.cluster_std,
-                size=(self.nodes_num // self.cluster_nums, 2),
-            )
-            cluster_points.append(points)
-        nodes_coords[i] = np.concatenate(cluster_points, axis=0)
+            for center in cluster_centers:
+                points = np.random.normal(
+                    loc=center,
+                    scale=self.cluster_std,
+                    size=(self.nodes_num // self.cluster_nums, 2),
+                )
+                cluster_points.append(points)
+            nodes_coords[i] = np.concatenate(cluster_points, axis=0)
         return nodes_coords
     
     ##################################


### PR DESCRIPTION
Hey Jiale,

I found a small but critical indentation issue in the `_generate_cluster` method within the `TSPDataGenerator`.

The current indentation causes the data generation loop to only produce one valid cluster instance for the entire batch, with all other instances being zero-arrays.

This PR fixes the indentation to ensure that each sample in the batch is correctly generated.

Cheers,
Nuoyan